### PR TITLE
basic https compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ target/
 
 /.idea
 /.idea_modules
+/bin/
+/.DS_Store

--- a/src/main/scala/io/github/cloudify/scala.spdf/PdfConfig.scala
+++ b/src/main/scala/io/github/cloudify/scala.spdf/PdfConfig.scala
@@ -142,6 +142,10 @@ trait PdfConfig {
   val outlineDepth = Parameter[Int]("outline-depth")
 
   val printMediaType = Parameter[Option[Boolean]]("print-media-type")
+  
+  val username = Parameter[String]("username")
+  
+  val password = Parameter[String]("password")
 
 }
 
@@ -222,7 +226,9 @@ object PdfConfig {
       tableOfContentNoDots.toParameter,
       title.toParameter,
       zoom.toParameter,
-      printMediaType.toParameter
+      printMediaType.toParameter,
+      username.toParameter,
+      password.toParameter
     ).flatten
   }
 

--- a/src/main/scala/io/github/cloudify/scala.spdf/SourceDocumentLike.scala
+++ b/src/main/scala/io/github/cloudify/scala.spdf/SourceDocumentLike.scala
@@ -69,7 +69,7 @@ object SourceDocumentLike {
   implicit object URLSourceDocument extends SourceDocumentLike[URL] {
 
     override def commandParameter(sourceDocument: URL) = sourceDocument.getProtocol match {
-      case "http" | "file" => sourceDocument.toString
+      case "https" | "http" | "file" => sourceDocument.toString
       case _ => throw new UnsupportedProtocolException(sourceDocument)
     }
 

--- a/src/test/scala/io/github/cloudify/scala/spdf/PdfConfigSpec.scala
+++ b/src/test/scala/io/github/cloudify/scala/spdf/PdfConfigSpec.scala
@@ -19,7 +19,7 @@ class PdfConfigSpec extends WordSpec with ShouldMatchers {
         orientation := Landscape
         zoom := 1.23f
       }
-      PdfConfig.toParameters(config) should equal(Seq("--forms", "--encoding", "UTF-8", "--margin-bottom", "1in", "--minimum-font-size", "3", "--orientation", "Landscape", "--zoom", "1.23"))
+      PdfConfig.toParameters(config) should equal(Seq("--forms", "--encoding", "UTF-8", "--margin-bottom", "1in", "--minimum-font-size", "3", "--orientation", "Landscape", "--zoom", "%.2f".format(1.23f)))
     }
 
     "print media type" in {

--- a/src/test/scala/io/github/cloudify/scala/spdf/SourceDocumentLikeSpec.scala
+++ b/src/test/scala/io/github/cloudify/scala/spdf/SourceDocumentLikeSpec.scala
@@ -2,7 +2,7 @@ package io.github.cloudify.scala.spdf
 
 import scala.sys.process.Process
 import io.github.cloudify.scala.spdf.SourceDocumentLike._
-import java.io.{File, ByteArrayInputStream}
+import java.io.{ File, ByteArrayInputStream }
 import java.net.URL
 import org.scalatest.WordSpec
 import org.scalatest.matchers.ShouldMatchers
@@ -32,8 +32,12 @@ class SourceDocumentLikeSpec extends WordSpec with ShouldMatchers with MockitoSu
     val input = new URL("http://www.google.com")
   }
 
-  trait unsupportedUrlInput {
+  trait httpsUrlInput {
     val input = new URL("https://www.google.com")
+  }
+
+  trait unsupportedUrlInput {
+    val input = new URL("ftp://ftp.google.com")
   }
 
   "SourceDocumentLike" should {
@@ -106,6 +110,23 @@ class SourceDocumentLikeSpec extends WordSpec with ShouldMatchers with MockitoSu
     }
 
     "leave process untouched" in new urlInput {
+      URLSourceDocument.sourceFrom(input)(catProcess) should equal(catProcess)
+    }
+
+    "throw an UnsupportedProtocolException if protocol is not supported" in new unsupportedUrlInput {
+      evaluating {
+        URLSourceDocument.commandParameter(input)
+      } should produce[UnsupportedProtocolException]
+    }
+  }
+
+  "httpsURLSourceDocument" should {
+
+    "have commandParameter set to URL" in new httpsUrlInput {
+      URLSourceDocument.commandParameter(input) should equal("https://www.google.com")
+    }
+
+    "leave process untouched" in new httpsUrlInput {
       URLSourceDocument.sourceFrom(input)(catProcess) should equal(catProcess)
     }
 


### PR DESCRIPTION
This pull request adds a basic https compatibility. Two parameters were added: username and password. Tested with wkhtmltopdf 0.12.1 (with pateched qt).
