### PR TITLE
Handling windows PATH detection for PdfConfig.findExecutable

### DIFF
--- a/src/main/scala/io/github/cloudify/scala.spdf/PdfConfig.scala
+++ b/src/main/scala/io/github/cloudify/scala.spdf/PdfConfig.scala
@@ -237,7 +237,10 @@ object PdfConfig {
    * @return
    */
   def findExecutable: Option[String] = try {
-    Option("which wkhtmltopdf".!!.trim).filter(_.nonEmpty)
+    val os = System.getProperty("os.name").toLowerCase
+    val cmd = if(os.contains("windows")) "where wkhtmltopdf" else "which wkhtmltopdf"
+
+    Option(cmd.!!.trim).filter(_.nonEmpty)
   } catch {
     case _: RuntimeException => None
   }

--- a/src/test/scala/io/github/cloudify/scala/spdf/PdfConfigSpec.scala
+++ b/src/test/scala/io/github/cloudify/scala/spdf/PdfConfigSpec.scala
@@ -36,6 +36,12 @@ class PdfConfigSpec extends WordSpec with ShouldMatchers {
       PdfConfig.toParameters(config) should contain("--no-print-media-type")
     }
 
+    "check for executable in PATH" in {
+      PdfConfig.findExecutable match {
+        case Some(path) => path.contains("wkhtmltopdf") should equal(true)
+        case None => true should equal(true)
+      }
+    }
   }
 
 }


### PR DESCRIPTION
Minor change for `PdfConfig.findExecutable` to use the `where` command for Windows.