### PR TITLE
Add ability to run wkhtmltopdf through xvfb-run to support headless debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,36 @@ libraryDependencies += "io.github.cloudify" %% "spdf" % "1.3.1"
 	pdf.run(new URL("http://www.google.com"), new File("google.pdf"))
 ```
 
+If you want to use sPDF in headless mode on debian you'll need to call to wkhtmltopdf through a virtualizer like xvfb-run.
+This is because wkhtmltopdf does not support running in headless mode on debian through the apt package. To use sPDF
+in this kind of environment you need to use WrappedPdf instead of Pdf. For Example:
+
+```scala
+	import io.github.cloudify.scala.spdf._
+	import java.io._
+	import java.net._
+
+	// Create a new Pdf converter with a custom configuration
+	// run `wkhtmltopdf --extended-help` for a full list of options
+	val pdf = WrappedPdf(Seq("xvfb-run", "wkhtmltopdf"), new PdfConfig {
+	  orientation := Landscape
+	  pageSize := "Letter"
+	  marginTop := "1in"
+	  marginBottom := "1in"
+	  marginLeft := "1in"
+	  marginRight := "1in"
+	})
+
+	val page = <html><body><h1>Hello World</h1></body></html>
+
+	// Save the PDF generated from the above HTML into a Byte Array
+	val outputStream = new ByteArrayOutputStream
+	pdf.run(page, outputStream)
+
+	// Save the PDF of Google's homepage into a file
+	pdf.run(new URL("http://www.google.com"), new File("google.pdf"))
+```
+
 ## Installing wkhtmltopdf ##
 
 Visit the [wkhtmltopdf downloads page](http://wkhtmltopdf.org/downloads.html) and install the appropriate package for your platform.

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ licenses := Seq(
 organization := "io.github.cloudify"
 
 /* scala versions and options */
-scalaVersion := "2.10.6"
+scalaVersion := "2.11.6"
 
 crossScalaVersions := Seq("2.9.3", "2.10.6", "2.11.7")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.2
+sbt.version=0.13.9

--- a/src/main/scala/io/github/cloudify/scala.spdf/WrappedPdf.scala
+++ b/src/main/scala/io/github/cloudify/scala.spdf/WrappedPdf.scala
@@ -1,0 +1,29 @@
+package io.github.cloudify.scala.spdf
+
+import scala.sys.process.Process
+
+class WrappedPdf(executable: Seq[String], config: PdfConfig) {
+
+  def run[A, B](sourceDocument: A, destinationDocument: B)(implicit sourceDocumentLike: SourceDocumentLike[A], destinationDocumentLike: DestinationDocumentLike[B]): Int = {
+    val commandLine = toCommandLine(sourceDocument, destinationDocument)
+    val process = Process(commandLine)
+
+    def source = sourceDocumentLike.sourceFrom(sourceDocument) _
+    def sink = destinationDocumentLike.sinkTo(destinationDocument) _
+
+    (sink compose source)(process).!
+  }
+
+  def toCommandLine[A: SourceDocumentLike, B: DestinationDocumentLike](source: A, destination: B): Seq[String] =
+    executable ++
+      PdfConfig.toParameters(config) ++
+      Seq(
+        "--quiet",
+        implicitly[SourceDocumentLike[A]].commandParameter(source),
+        implicitly[DestinationDocumentLike[B]].commandParameter(destination)
+      )
+}
+
+object WrappedPdf {
+  def apply(executable: Seq[String], config: PdfConfig): WrappedPdf = new WrappedPdf(executable, config)
+}

--- a/src/test/scala/io/github/cloudify/scala/spdf/WrappedPdfSpec.scala
+++ b/src/test/scala/io/github/cloudify/scala/spdf/WrappedPdfSpec.scala
@@ -1,0 +1,37 @@
+package io.github.cloudify.scala.spdf
+
+import java.io.File
+import scala.sys.process._
+import org.scalatest.matchers.ShouldMatchers
+import org.scalatest.WordSpec
+
+class WrappedPdfSpec extends WordSpec with ShouldMatchers {
+
+  "A Pdf" should {
+
+    PdfConfig.findExecutable match {
+      case Some(_) =>
+        "generate a PDF file from an HTML string" in {
+
+          val page =
+            """
+              |<html><body><h1>Hello</h1></body></html>
+            """.stripMargin
+
+          val file = File.createTempFile("scala.spdf", "pdf")
+
+          val pdf = WrappedPdf(Seq("wkhtmltopdf"), PdfConfig.default)
+
+          pdf.run(page, file)
+
+          Seq("file", file.getAbsolutePath).!! should include("PDF document")
+        }
+
+      case None =>
+        "Skipping test, missing wkhtmltopdf binary" in { true should equal(true) }
+    }
+
+
+  }
+
+}


### PR DESCRIPTION
Make it possible to provide a Seq to the Process constructor and avoid validation of executable files.
