### PR TITLE
Move --forms CLI arg -> --enable-forms

### DIFF
--- a/src/main/scala/io/github/cloudify/scala.spdf/PdfConfig.scala
+++ b/src/main/scala/io/github/cloudify/scala.spdf/PdfConfig.scala
@@ -32,7 +32,7 @@ trait PdfConfig {
 
   val javascriptDelay = Parameter[Int]("javascript-delay")
 
-  val convertForms = Parameter[Boolean]("forms")
+  val enableForms = Parameter[Boolean]("enable-forms")
 
   val encoding = Parameter[String]("encoding", "UTF-8")
 
@@ -175,7 +175,6 @@ object PdfConfig {
     Seq(
       allow.toParameter,
       background.toParameter,
-      convertForms.toParameter,
       defaultHeader.toParameter,
       disableExternalLinks.toParameter,
       disableInternalLinks.toParameter,
@@ -183,6 +182,7 @@ object PdfConfig {
       noPdfCompression.toParameter,
       disableSmartShrinking.toParameter,
       javascriptDelay.toParameter,
+      enableForms.toParameter,
       encoding.toParameter,
       footerCenter.toParameter,
       footerFontName.toParameter,

--- a/src/test/scala/io/github/cloudify/scala/spdf/PdfConfigSpec.scala
+++ b/src/test/scala/io/github/cloudify/scala/spdf/PdfConfigSpec.scala
@@ -13,13 +13,13 @@ class PdfConfigSpec extends WordSpec with ShouldMatchers {
 
     "generate parameters from config" in {
       val config = new PdfConfig {
-        convertForms := true
+        enableForms := true
         marginBottom := "1in"
         minimumFontSize := 3
         orientation := Landscape
         zoom := 1.23f
       }
-      PdfConfig.toParameters(config) should equal(Seq("--forms", "--encoding", "UTF-8", "--margin-bottom", "1in", "--minimum-font-size", "3", "--orientation", "Landscape", "--zoom", "%.2f".format(1.23f)))
+      PdfConfig.toParameters(config) should equal(Seq("--enable-forms", "--encoding", "UTF-8", "--margin-bottom", "1in", "--minimum-font-size", "3", "--orientation", "Landscape", "--zoom", "%.2f".format(1.23f)))
     }
 
     "no pdf compression" in {


### PR DESCRIPTION
Currently, a pdfconfig like

```
new PdfConfig {
  convertForms := true
}
```

creates a command line argument of `usr/local/bin/wkhtmltopdf --forms`. However that CLI argument seems to have been deprecated in favour of `--enable-forms` and `--disable-forms`. This is my first attempt at updating sPDF to match that behaviour.
