### PR TITLE
Auto detect xvfb-run and will use it together with wkhtmltopdf if exists

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.1.6

--- a/src/main/scala/io/github/cloudify/scala.spdf/Pdf.scala
+++ b/src/main/scala/io/github/cloudify/scala.spdf/Pdf.scala
@@ -22,14 +22,19 @@ class Pdf(executablePath: String, config: PdfConfig) {
   /**
    * Generates the command line needed to execute `wkhtmltopdf`
    */
-  private def toCommandLine[A: SourceDocumentLike, B: DestinationDocumentLike](source: A, destination: B): Seq[String] =
-    Seq(executablePath) ++
-      PdfConfig.toParameters(config) ++
-      Seq(
-        "--quiet",
-        implicitly[SourceDocumentLike[A]].commandParameter(source),
-        implicitly[DestinationDocumentLike[B]].commandParameter(destination)
-      )
+  private def toCommandLine[A: SourceDocumentLike, B: DestinationDocumentLike](source: A, destination: B): Seq[String] = {
+    val XVFB = "xvfb-run"
+    val execPath = PdfConfig.findExecutablePath(XVFB) match {
+      case Some(xvfbPath) if xvfbPath.contains(XVFB) => Seq(xvfbPath, "--", executablePath)
+      case _ => Seq(executablePath)
+    }
+
+    execPath ++  PdfConfig.toParameters(config) ++ Seq(
+      "--quiet",
+      implicitly[SourceDocumentLike[A]].commandParameter(source),
+      implicitly[DestinationDocumentLike[B]].commandParameter(destination)
+    )
+  }
 
   /**
    * Check whether the executable is actually executable, if it isn't

--- a/src/main/scala/io/github/cloudify/scala.spdf/PdfConfig.scala
+++ b/src/main/scala/io/github/cloudify/scala.spdf/PdfConfig.scala
@@ -253,9 +253,11 @@ object PdfConfig {
    * Attempts to find the `wkhtmltopdf` executable in the system path.
    * @return
    */
-  def findExecutable: Option[String] = try {
+  def findExecutable: Option[String] = findExecutablePath("wkhtmltopdf")
+
+  def findExecutablePath(exec: String): Option[String] = try {
     val os = System.getProperty("os.name").toLowerCase
-    val cmd = if(os.contains("windows")) "where wkhtmltopdf" else "which wkhtmltopdf"
+    val cmd = if(os.contains("windows")) s"where $exec" else s"which $exec"
 
     Option(cmd.!!.trim).filter(_.nonEmpty)
   } catch {


### PR DESCRIPTION
Hi Federico,
I have created a patch to enable sPDF to auto detect xvfb-run, if it exists it will run wkhtmltopdf using xvfb-run. This would allow sPDF to run in a headless Ubuntu 18.04 server or any other debian headless server.
